### PR TITLE
Deprecate this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,15 @@
-# telemetry-framework  [![Build Status](https://travis-ci.org/redhat-service-assurance/telemetry-framework.svg?branch=master)](https://travis-ci.org/redhat-service-assurance/telemetry-framework)
+# DEPRECATED REPOSITORY telemetry-framework
 
-The telemetry framework is a project that aims to centralize metrics and events
-of various platform components (not applications) in order to provide a
-centralized view of multiple platform deployments.
+Active work has moved here: https://github.com/redhat-service-assurance/service-assurance-operator/
 
-## Development
-
-The quickest way to start up Service Assurance Framework is to run the
-`quickstart.sh` script located in the `deploy/` directory after starting up a
-[Code Ready Containers](https://github.com/code-ready/crc) environment.
+The contents of this repository remain in orer to preserve WIP patches (please delete your branches when you're done) and supporting existing Tech Preview installations.
 
 ## Tech Preview
+
 See the [official
 documentation](https://redhat-service-assurance.github.io/saf-documentation)
 for more information about installing for production-style use cases on OCP3.
 
-Please use the `saf-ocp3` branch for all such installations. 
+Please use [the legacy saf-ocp3 branch](https://github.com/redhat-service-assurance/telemetry-framework/tree/saf-ocp3) for all such installations.
+
+As of the SAF GA release, this repository is deprecated.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Active work has moved here: https://github.com/redhat-service-assurance/service-assurance-operator/
 
-The contents of this repository remain in orer to preserve WIP patches (please delete your branches when you're done) and supporting existing Tech Preview installations.
+The contents of this repository remain in order to preserve WIP patches (please delete your branches when you're done) and supporting existing Tech Preview installations.
 
 ## Tech Preview
 
@@ -12,4 +12,4 @@ for more information about installing for production-style use cases on OCP3.
 
 Please use [the legacy saf-ocp3 branch](https://github.com/redhat-service-assurance/telemetry-framework/tree/saf-ocp3) for all such installations.
 
-As of the SAF GA release, this repository is deprecated.
+As of the Generally Available SAF release, this repository is deprecated.


### PR DESCRIPTION
Active work has moved here: https://github.com/redhat-service-assurance/service-assurance-operator/

Also, see this PR: https://github.com/redhat-service-assurance/service-assurance-operator/pull/34

More detail on Trello 898