### PR TITLE
Build nodes list automatically

### DIFF
--- a/deploy/dashboard/rhos-dashboard.yaml.template
+++ b/deploy/dashboard/rhos-dashboard.yaml.template
@@ -2785,11 +2785,7 @@
     "list": [
       {
         "allValue": null,
-        "current": {
-          "selected": false,
-          "text": "controller-0.localdomain",
-          "value": "controller-0.localdomain"
-        },
+        "current": {},
         "datasource": "SAFPrometheus",
         "definition": "label_values(exported_instance)",
         "hide": 0,
@@ -2797,43 +2793,12 @@
         "label": "nodes",
         "multi": false,
         "name": "exported_instances",
-        "options": [
-          {
-            "selected": false,
-            "text": "172.17.1.16",
-            "value": "172.17.1.16"
-          },
-          {
-            "selected": false,
-            "text": "compute-0.localdomain",
-            "value": "compute-0.localdomain"
-          },
-          {
-            "selected": false,
-            "text": "compute-0.localdomain:2066b66a-70c0-47d7-911a-7e8de613614d",
-            "value": "compute-0.localdomain:2066b66a-70c0-47d7-911a-7e8de613614d"
-          },
-          {
-            "selected": false,
-            "text": "compute-0.localdomain:879507e0-ad7e-4585-ae96-167727bfc6be",
-            "value": "compute-0.localdomain:879507e0-ad7e-4585-ae96-167727bfc6be"
-          },
-          {
-            "selected": true,
-            "text": "controller-0.localdomain",
-            "value": "controller-0.localdomain"
-          },
-          {
-            "selected": false,
-            "text": "localhost",
-            "value": "localhost"
-          }
-        ],
+        "options": [],
         "query": "label_values(exported_instance)",
-        "refresh": 0,
+        "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",


### PR DESCRIPTION
Paul and I were looking at why my dashboard import wasn't returning data even
though the datasource looked right, and connections were working as expected.

Looking further, Paul noticed that the drop down for the nodes wasn't in sync
with the exported_instance values we were seeing in the Prometheus query.
Updating the variable in the dashboard to sync it to what was returned by
Prometheus allowed things to work.

I looked at my old dashboard where I knew I didn't need to do that sync, which
you can originally see imported here: https://github.com/redhat-service-assurance/telemetry-framework/blob/43738e15cf504b31a7a69cc901b2dcdbfe044408/deploy/service-assurance/grafana/configmap-dashboard-definitions.yaml

This change results in the 'nodes' list populating based on the values returned and
not from a static re-generated list.